### PR TITLE
Bcm2711 PCI, Final round of cleanups, two bug fixes

### DIFF
--- a/Platform/RaspberryPi/RPi4/RPi4.dsc
+++ b/Platform/RaspberryPi/RPi4/RPi4.dsc
@@ -628,7 +628,7 @@
       DmaLib|EmbeddedPkg/Library/NonCoherentDmaLib/NonCoherentDmaLib.inf
     <PcdsFixedAtBuild>
       gEmbeddedTokenSpaceGuid.PcdDmaDeviceOffset|0x00000000
-      gEmbeddedTokenSpaceGuid.PcdDmaDeviceLimit|0xffffffff
+      gEmbeddedTokenSpaceGuid.PcdDmaDeviceLimit|0xbfffffff
   }
 
   #

--- a/Platform/RaspberryPi/RPi4/RPi4.dsc
+++ b/Platform/RaspberryPi/RPi4/RPi4.dsc
@@ -385,6 +385,13 @@
   gBcm27xxTokenSpaceGuid.PcdBcm27xxRegistersAddress|0xfc000000
   gBcm283xTokenSpaceGuid.PcdBcm283xRegistersAddress|0xfe000000
 
+  # PCIe specific addresses
+  gBcm27xxTokenSpaceGuid.PcdBcm27xxPciRegBase|0xfd500000
+  gBcm27xxTokenSpaceGuid.PcdBcm27xxPciBusMmioAdr|0xf8000000
+  gBcm27xxTokenSpaceGuid.PcdBcm27xxPciBusMmioLen|0x3FFFFFF
+  gBcm27xxTokenSpaceGuid.PcdBcm27xxPciCpuMmioAdr|0x600000000
+
+
   ## NS16550 compatible UART
   gEfiMdeModulePkgTokenSpaceGuid.PcdSerialRegisterBase|0xfe215040
   gEfiMdeModulePkgTokenSpaceGuid.PcdSerialUseMmio|TRUE

--- a/Silicon/Broadcom/Bcm27xx/Bcm27xx.dec
+++ b/Silicon/Broadcom/Bcm27xx/Bcm27xx.dec
@@ -20,3 +20,7 @@
 
 [PcdsFixedAtBuild.common]
   gBcm27xxTokenSpaceGuid.PcdBcm27xxRegistersAddress|0x0|UINT32|0x00000001
+  gBcm27xxTokenSpaceGuid.PcdBcm27xxPciRegBase|0x0|UINT32|0x00000002
+  gBcm27xxTokenSpaceGuid.PcdBcm27xxPciBusMmioAdr|0x0|UINT64|0x00000003
+  gBcm27xxTokenSpaceGuid.PcdBcm27xxPciBusMmioLen|0x0|UINT32|0x00000004
+  gBcm27xxTokenSpaceGuid.PcdBcm27xxPciCpuMmioAdr|0x0|UINT64|0x00000005

--- a/Silicon/Broadcom/Bcm27xx/Include/IndustryStandard/Bcm2711.h
+++ b/Silicon/Broadcom/Bcm27xx/Include/IndustryStandard/Bcm2711.h
@@ -14,12 +14,12 @@
 #define BCM2711_SOC_REGISTER_LENGTH         0x02000000
 
 /* Generic PCI addresses */
-#define PCIE_TOP_OF_MEM_WIN                                 0xf8000000UL
-#define PCIE_CPU_MMIO_WINDOW                                0x600000000UL
-#define PCIE_BRIDGE_MMIO_LEN                                0x3FFFFFFUL
+#define PCIE_TOP_OF_MEM_WIN                                 (FixedPcdGet64 (PcdBcm27xxPciBusMmioAdr))
+#define PCIE_CPU_MMIO_WINDOW                                (FixedPcdGet64 (PcdBcm27xxPciCpuMmioAdr))
+#define PCIE_BRIDGE_MMIO_LEN                                (FixedPcdGet32 (PcdBcm27xxPciBusMmioLen))
 
 /* PCI root bridge control registers location */
-#define PCIE_REG_BASE                                       0xfd500000  // Base post translation? not working at the moment
+#define PCIE_REG_BASE                                       (FixedPcdGet32 (PcdBcm27xxPciRegBase))
 #define PCIE_REG_LIMIT                                      0x9310
 
 /* PCI root bridge control registers */

--- a/Silicon/Broadcom/Bcm27xx/Include/IndustryStandard/Bcm2711.h
+++ b/Silicon/Broadcom/Bcm27xx/Include/IndustryStandard/Bcm2711.h
@@ -16,7 +16,7 @@
 /* Generic PCI addresses */
 #define PCIE_TOP_OF_MEM_WIN                                 0xf8000000UL
 #define PCIE_CPU_MMIO_WINDOW                                0x600000000UL
-#define PCIE_BRIDGE_MMIO_WINDOW                             0x4000000UL
+#define PCIE_BRIDGE_MMIO_LEN                                0x3FFFFFFUL
 
 /* PCI root bridge control registers location */
 #define PCIE_REG_BASE                                       0xfd500000  // Base post translation? not working at the moment
@@ -82,53 +82,5 @@
 #define BURST_SIZE_128                                      0
 #define BURST_SIZE_256                                      1
 #define BURST_SIZE_512                                      2
-
-#define PCI_EXP_LNKCAP                                      12          /* Link Capabilities */
-#define PCI_EXP_LNKCAP_SLS                                  0x0000000f  /* Supported Link Speeds */
-#define PCI_EXP_LNKCAP_SLS_2_5GB                            0x00000001  /* LNKCAP2 SLS Vector bit 0 */
-#define PCI_EXP_LNKCAP_SLS_5_0GB                            0x00000002  /* LNKCAP2 SLS Vector bit 1 */
-#define PCI_EXP_LNKCAP_SLS_8_0GB                            0x00000003  /* LNKCAP2 SLS Vector bit 2 */
-#define PCI_EXP_LNKCAP_SLS_16_0GB                           0x00000004  /* LNKCAP2 SLS Vector bit 3 */
-#define PCI_EXP_LNKCAP_SLS_32_0GB                           0x00000005  /* LNKCAP2 SLS Vector bit 4 */
-#define PCI_EXP_LNKCAP_MLW                                  0x000003f0  /* Maximum Link Width */
-#define PCI_EXP_LNKCAP_ASPMS                                0x00000c00  /* ASPM Support */
-#define PCI_EXP_LNKCAP_L0SEL                                0x00007000  /* L0s Exit Latency */
-#define PCI_EXP_LNKCAP_L1EL                                 0x00038000  /* L1 Exit Latency */
-#define PCI_EXP_LNKCAP_CLKPM                                0x00040000  /* Clock Power Management */
-#define PCI_EXP_LNKCAP_SDERC                                0x00080000  /* Surprise Down Error Reporting Capable */
-#define PCI_EXP_LNKCAP_DLLLARC                              0x00100000  /* Data Link Layer Link Active Reporting Capable */
-#define PCI_EXP_LNKCAP_LBNC                                 0x00200000  /* Link Bandwidth Notification Capability */
-#define PCI_EXP_LNKCAP_PN                                   0xff000000  /* Port Number */
-#define PCI_EXP_LNKCTL                                      16          /* Link Control */
-#define PCI_EXP_LNKCTL_ASPMC                                0x0003      /* ASPM Control */
-#define PCI_EXP_LNKCTL_ASPM_L0S                             0x0001      /* L0s Enable */
-#define PCI_EXP_LNKCTL_ASPM_L1                              0x0002      /* L1 Enable */
-#define PCI_EXP_LNKCTL_RCB                                  0x0008      /* Read Completion Boundary */
-#define PCI_EXP_LNKCTL_LD                                   0x0010      /* Link Disable */
-#define PCI_EXP_LNKCTL_RL                                   0x0020      /* Retrain Link */
-#define PCI_EXP_LNKCTL_CCC                                  0x0040      /* Common Clock Configuration */
-#define PCI_EXP_LNKCTL_ES                                   0x0080      /* Extended Synch */
-#define PCI_EXP_LNKCTL_CLKREQ_EN                            0x0100      /* Enable clkreq */
-#define PCI_EXP_LNKCTL_HAWD                                 0x0200      /* Hardware Autonomous Width Disable */
-#define PCI_EXP_LNKCTL_LBMIE                                0x0400      /* Link Bandwidth Management Interrupt Enable */
-#define PCI_EXP_LNKCTL_LABIE                                0x0800      /* Link Autonomous Bandwidth Interrupt Enable */
-#define PCI_EXP_LNKSTA                                      18          /* Link Status */
-#define PCI_EXP_LNKSTA_CLS                                  0x000f      /* Current Link Speed */
-#define PCI_EXP_LNKSTA_CLS_2_5GB                            0x0001      /* Current Link Speed 2.5GT/s */
-#define PCI_EXP_LNKSTA_CLS_5_0GB                            0x0002      /* Current Link Speed 5.0GT/s */
-#define PCI_EXP_LNKSTA_CLS_8_0GB                            0x0003      /* Current Link Speed 8.0GT/s */
-#define PCI_EXP_LNKSTA_CLS_16_0GB                           0x0004      /* Current Link Speed 16.0GT/s */
-#define PCI_EXP_LNKSTA_CLS_32_0GB                           0x0005      /* Current Link Speed 32.0GT/s */
-#define PCI_EXP_LNKSTA_NLW                                  0x03f0      /* Negotiated Link Width */
-#define PCI_EXP_LNKSTA_NLW_X1                               0x0010      /* Current Link Width x1 */
-#define PCI_EXP_LNKSTA_NLW_X2                               0x0020      /* Current Link Width x2 */
-#define PCI_EXP_LNKSTA_NLW_X4                               0x0040      /* Current Link Width x4 */
-#define PCI_EXP_LNKSTA_NLW_X8                               0x0080      /* Current Link Width x8 */
-#define PCI_EXP_LNKSTA_NLW_SHIFT                            4           /* Start of NLW mask in link status */
-#define PCI_EXP_LNKSTA_LT                                   0x0800      /* Link Training */
-#define PCI_EXP_LNKSTA_SLC                                  0x1000      /* Slot Clock Configuration */
-#define PCI_EXP_LNKSTA_DLLLA                                0x2000      /* Data Link Layer Link Active */
-#define PCI_EXP_LNKSTA_LBMS                                 0x4000      /* Link Bandwidth Management Status */
-#define PCI_EXP_LNKSTA_LABS                                 0x8000      /* Link Autonomous Bandwidth Status */
 
 #endif /* BCM2711_H__ */

--- a/Silicon/Broadcom/Bcm27xx/Library/Bcm2711PciHostBridgeLib/Bcm2711PciHostBridgeLib.c
+++ b/Silicon/Broadcom/Bcm27xx/Library/Bcm2711PciHostBridgeLib/Bcm2711PciHostBridgeLib.c
@@ -9,6 +9,7 @@
  *
  **/
 
+#include <IndustryStandard/Bcm2711.h>
 #include <IndustryStandard/Pci22.h>
 #include <Library/DebugLib.h>
 #include <Library/DevicePathLib.h>
@@ -59,9 +60,6 @@ CHAR16 *mPciHostBridgeLibAcpiAddressSpaceTypeStr[] = {
   L"Mem", L"I/O", L"Bus"
 };
 
-#define PCI_ALLOCATION_ATTRIBUTES       EFI_PCI_HOST_BRIDGE_COMBINE_MEM_PMEM
-
-
 // these should come from the pcd...
 #define BCM2711_PCI_SEG0_BUSNUM_MIN     0x00
 #define BCM2711_PCI_SEG0_BUSNUM_MAX     0xFF
@@ -69,10 +67,10 @@ CHAR16 *mPciHostBridgeLibAcpiAddressSpaceTypeStr[] = {
 #define BCM2711_PCI_SEG0_PORTIO_MAX     0x00 //MIN>MAX disables PIO
 #define BCM2711_PCI_SEG0_PORTIO_OFFSET  0x00
 // the bridge thinks its MMIO is here (which means it can't access this area in phy ram)
-#define BCM2711_PCI_SEG0_MMIO32_MIN     0xf8000000
-#define BCM2711_PCI_SEG0_MMIO32_MAX     (0xf8000000+0x03ffffff)
+#define BCM2711_PCI_SEG0_MMIO32_MIN     PCIE_TOP_OF_MEM_WIN
+#define BCM2711_PCI_SEG0_MMIO32_MAX     (PCIE_TOP_OF_MEM_WIN+PCIE_BRIDGE_MMIO_LEN)
 // the CPU views it via a window here..
-#define BCM2711_PCI_SEG0_MMIO32_XLATE   (0x600000000-0xf8000000)
+#define BCM2711_PCI_SEG0_MMIO32_XLATE   (PCIE_CPU_MMIO_WINDOW-PCIE_TOP_OF_MEM_WIN)
 
 // we might be able to size another region?
 #define BCM2711_PCI_SEG0_MMIO64_MIN     0x00
@@ -89,7 +87,7 @@ PCI_ROOT_BRIDGE mPciRootBridges[] = {
     FALSE,                                  // DmaAbove4G
     FALSE,                                  // NoExtendedConfigSpace (true=256 byte config, false=4k)
     FALSE,                                  // ResourceAssigned
-    PCI_ALLOCATION_ATTRIBUTES,              // AllocationAttributes
+    EFI_PCI_HOST_BRIDGE_COMBINE_MEM_PMEM,   // AllocationAttributes
     { BCM2711_PCI_SEG0_BUSNUM_MIN,
       BCM2711_PCI_SEG0_BUSNUM_MAX },        // Bus
     { BCM2711_PCI_SEG0_PORTIO_MIN,

--- a/Silicon/Broadcom/Bcm27xx/Library/Bcm2711PciHostBridgeLib/Bcm2711PciHostBridgeLib.inf
+++ b/Silicon/Broadcom/Bcm27xx/Library/Bcm2711PciHostBridgeLib/Bcm2711PciHostBridgeLib.inf
@@ -45,13 +45,7 @@
   UefiBootServicesTableLib
 
 [FixedPcd]
-  gArmTokenSpaceGuid.PcdPciIoTranslation
-
-[Pcd]
-#  gSynQuacerTokenSpaceGuid.PcdPcieEnableMask
-#  gSynQuacerTokenSpaceGuid.PcdPlatformSettings
-
-[Depex]
-  # xTokenSpaceGuid.PcdPlatformSettings may be of the dynamic HII
-  # variety, which are backed by EFI variables
-#  gEfiVariableArchProtocolGuid
+  gBcm27xxTokenSpaceGuid.PcdBcm27xxPciRegBase
+  gBcm27xxTokenSpaceGuid.PcdBcm27xxPciBusMmioAdr
+  gBcm27xxTokenSpaceGuid.PcdBcm27xxPciBusMmioLen
+  gBcm27xxTokenSpaceGuid.PcdBcm27xxPciCpuMmioAdr

--- a/Silicon/Broadcom/Bcm27xx/Library/Bcm2711PciHostBridgeLib/Bcm2711PciHostBridgeLibConstructor.c
+++ b/Silicon/Broadcom/Bcm27xx/Library/Bcm2711PciHostBridgeLib/Bcm2711PciHostBridgeLibConstructor.c
@@ -58,7 +58,7 @@ RMWRegister (
   if (In) {
     while (!(Mask & Shift))
       Shift <<= 1;
-    Data = (MmioRead32 (Addr) & ~Mask) | (In * Shift);
+    Data = (MmioRead32 (Addr) & ~Mask) | ((In * Shift) & Mask);
   } else {
     Data = MmioRead32 (Addr) & ~Mask;
   }
@@ -170,9 +170,9 @@ Bcm2711PciHostBridgeLibConstructor (
   DEBUG ((DEBUG_VERBOSE, "RootBridge: MMIO CPU addr %llx\n", CpuAddrStart));
 
   RMWRegister (PCIE_MISC_CPU_2_PCIE_MEM_WIN0_BASE_LIMIT,
-    PCIE_MISC_CPU_2_PCIE_MEM_WIN0_BASE_LIMIT_BASE_MASK, CpuAddrStart >> 16);
+    PCIE_MISC_CPU_2_PCIE_MEM_WIN0_BASE_LIMIT_BASE_MASK, CpuAddrStart >> 20);
   RMWRegister (PCIE_MISC_CPU_2_PCIE_MEM_WIN0_BASE_LIMIT,
-    PCIE_MISC_CPU_2_PCIE_MEM_WIN0_BASE_LIMIT_LIMIT_MASK, CpuAddrEnd >> 16);
+    PCIE_MISC_CPU_2_PCIE_MEM_WIN0_BASE_LIMIT_LIMIT_MASK, CpuAddrEnd >> 20);
   RMWRegister (PCIE_MISC_CPU_2_PCIE_MEM_WIN0_BASE_HI,
     PCIE_MISC_CPU_2_PCIE_MEM_WIN0_BASE_HI_BASE_MASK, CpuAddrStart >> 32);
   RMWRegister (PCIE_MISC_CPU_2_PCIE_MEM_WIN0_LIMIT_HI,

--- a/Silicon/Broadcom/Bcm27xx/Library/Bcm2711PciHostBridgeLib/Bcm2711PciHostBridgeLibConstructor.c
+++ b/Silicon/Broadcom/Bcm27xx/Library/Bcm2711PciHostBridgeLib/Bcm2711PciHostBridgeLibConstructor.c
@@ -27,39 +27,17 @@
 #include <PiDxe.h>
 #include <Protocol/PciHostBridgeResourceAllocation.h>
 
-STATIC UINT32 BogusCatch;
-
 STATIC
 UINT32
 RdRegister (
-  UINT32                Offset,
-  UINT32                Mask
+  UINT32                Offset
   )
 {
   EFI_PHYSICAL_ADDRESS  Base = PCIE_REG_BASE;
 
   ArmDataMemoryBarrier ();
-  if (!Mask) //hmmm maybe C++'s default parms are useful?
-      Mask = (UINT32)-1;
 
-  return MmioRead32 (Base + Offset) & Mask;
-}
-
-
-STATIC
-UINT32
-RdRegister16 (
-  UINT32                Offset,
-  UINT32                Mask
-  )
-{
-  EFI_PHYSICAL_ADDRESS  Base = PCIE_REG_BASE;
-
-  ArmDataMemoryBarrier ();
-  if (!Mask) //hmmm maybe C++'s default parms are useful?
-      Mask = (UINT32)-1;
-
-  return MmioRead16 (Base + Offset) & Mask;
+  return MmioRead32 (Base + Offset);
 }
 
 
@@ -85,11 +63,10 @@ RMWRegister (
     Data = MmioRead32 (Addr) & ~Mask;
   }
 
-  DEBUG ((DEBUG_ERROR, "RootBridge pci write %x to %x\n", Data, Addr));
+//  DEBUG ((DEBUG_ERROR, "RootBridge pci write %x to %x\n", Data, Addr));
   MmioWrite32 (Addr, Data);
 
   ArmDataMemoryBarrier ();
-  BogusCatch = RdRegister(Offset, 0);
 }
 
 
@@ -103,10 +80,9 @@ WdRegister (
   EFI_PHYSICAL_ADDRESS  Base = PCIE_REG_BASE;
 
   MmioWrite32 (Base + Offset, In);
-  DEBUG ((DEBUG_ERROR, "RootBridge pci write %x to %x\n", In, Base+Offset));
+//  DEBUG ((DEBUG_ERROR, "RootBridge pci write %x to %x\n", In, Base+Offset));
 
   ArmDataMemoryBarrier ();
-  BogusCatch = RdRegister(Offset, 0);
 }
 
 
@@ -121,7 +97,7 @@ Bcm2711PciHostBridgeLibConstructor (
   UINT32                Data;
   EFI_PHYSICAL_ADDRESS  TopOfPciMap;
 
-  DEBUG ((DEBUG_ERROR, "RootBridge constructor\n"));
+  DEBUG ((DEBUG_VERBOSE, "PCIe RootBridge constructor\n"));
 
   // Reset controller
   RMWRegister (PCIE_RGR1_SW_INIT_1, PCIE_RGR1_SW_INIT_1_INIT_MASK, 1);
@@ -134,13 +110,13 @@ Bcm2711PciHostBridgeLibConstructor (
 
 
   RMWRegister (PCIE_MISC_HARD_PCIE_HARD_DEBUG, PCIE_MISC_HARD_PCIE_HARD_DEBUG_SERDES_IDDQ_MASK, 0);
-  RdRegister (PCIE_MISC_HARD_PCIE_HARD_DEBUG, 0);
+  RdRegister (PCIE_MISC_HARD_PCIE_HARD_DEBUG);
   // Wait for SerDes to be stable
   gBS->Stall (1000);
 
   // Read revision
-  Data = RdRegister (PCIE_MISC_REVISION, PCIE_MISC_REVISION_MAJMIN_MASK); //0xffff
-  DEBUG ((DEBUG_ERROR, "RootBridge: Revision %x\n", Data));
+  Data = RdRegister (PCIE_MISC_REVISION);
+  DEBUG ((DEBUG_INFO, "RootBridge: Revision %x\n", Data & PCIE_MISC_REVISION_MAJMIN_MASK));
 
   RMWRegister (PCIE_MISC_MISC_CTRL, PCIE_MISC_MISC_CTRL_SCB_ACCESS_EN_MASK, 1);
   RMWRegister (PCIE_MISC_MISC_CTRL, PCIE_MISC_MISC_CTRL_CFG_READ_UR_MODE_MASK, 1);
@@ -159,7 +135,7 @@ Bcm2711PciHostBridgeLibConstructor (
   // The size parms are 1GB=0xf=log2(size)-15), or 4G=0x11
   //
 
-  DEBUG ((DEBUG_ERROR, "RootBridge: Program bottom 4G of ram\n"));
+  DEBUG ((DEBUG_VERBOSE, "RootBridge: Program bottom 4G of ram\n"));
 
   // lets assume a start addr of 0, size 4G
   WdRegister (PCIE_MISC_RC_BAR2_CONFIG_LO, 0x11);   /* Size = 4G */
@@ -173,7 +149,7 @@ Bcm2711PciHostBridgeLibConstructor (
 
   TopOfPciMap = PCIE_TOP_OF_MEM_WIN;
 
-  DEBUG ((DEBUG_ERROR, "RootBridge: MMIO PCIe addr %llx\n", TopOfPciMap));
+  DEBUG ((DEBUG_VERBOSE, "RootBridge: MMIO PCIe addr %llx\n", TopOfPciMap));
   // See brcm_pcie_set_outbound_win() in the raspberrypi tree
   WdRegister (PCIE_MISC_CPU_2_PCIE_MEM_WIN0_LO, TopOfPciMap);
   WdRegister (PCIE_MISC_CPU_2_PCIE_MEM_WIN0_HI, TopOfPciMap >> 32); // 4GB? and bounce or just map the whole thing?
@@ -189,14 +165,14 @@ Bcm2711PciHostBridgeLibConstructor (
   // The mapping should be 1:1 if possible
   //
   EFI_PHYSICAL_ADDRESS    CpuAddrStart = PCIE_CPU_MMIO_WINDOW;
-  EFI_PHYSICAL_ADDRESS    CpuAddrEnd   = CpuAddrStart + PCIE_BRIDGE_MMIO_WINDOW;
+  EFI_PHYSICAL_ADDRESS    CpuAddrEnd   = CpuAddrStart + PCIE_BRIDGE_MMIO_LEN;
 
-  DEBUG ((DEBUG_ERROR, "RootBridge: MMIO CPU addr %llx\n", CpuAddrStart));
+  DEBUG ((DEBUG_VERBOSE, "RootBridge: MMIO CPU addr %llx\n", CpuAddrStart));
 
   RMWRegister (PCIE_MISC_CPU_2_PCIE_MEM_WIN0_BASE_LIMIT,
     PCIE_MISC_CPU_2_PCIE_MEM_WIN0_BASE_LIMIT_BASE_MASK, CpuAddrStart >> 16);
   RMWRegister (PCIE_MISC_CPU_2_PCIE_MEM_WIN0_BASE_LIMIT,
-    PCIE_MISC_CPU_2_PCIE_MEM_WIN0_BASE_LIMIT_LIMIT_MASK, (CpuAddrEnd-1) >> 16);
+    PCIE_MISC_CPU_2_PCIE_MEM_WIN0_BASE_LIMIT_LIMIT_MASK, CpuAddrEnd >> 16);
   RMWRegister (PCIE_MISC_CPU_2_PCIE_MEM_WIN0_BASE_HI,
     PCIE_MISC_CPU_2_PCIE_MEM_WIN0_BASE_HI_BASE_MASK, CpuAddrStart >> 32);
   RMWRegister (PCIE_MISC_CPU_2_PCIE_MEM_WIN0_LIMIT_HI,
@@ -206,7 +182,6 @@ Bcm2711PciHostBridgeLibConstructor (
   // Consider MSI setup here, not that it matters much its likely the legacy intX
   // is as fast or faster...
   //
-  DEBUG ((DEBUG_ERROR, "RootBridge: clear ints\n"));
 
   // Clear and mask interrupts.
   WdRegister (PCIE_INTR2_CPU_MASK_CLR, 0xffffffff);
@@ -218,15 +193,15 @@ Bcm2711PciHostBridgeLibConstructor (
 
   // De-assert PERST
   RMWRegister (PCIE_RGR1_SW_INIT_1, PCIE_RGR1_SW_INIT_1_PERST_MASK, 0);
-  DEBUG ((DEBUG_ERROR, "RootBridge: Reset done\n"));
+  DEBUG ((DEBUG_VERBOSE, "RootBridge: Reset done\n"));
 
   // Wait for linkup
   do {
-      Data = RdRegister (PCIE_MISC_PCIE_STATUS, 0);
+      Data = RdRegister (PCIE_MISC_PCIE_STATUS);
       gBS->Stall (1000);
       Timeout --;
   } while (((Data & 0x30) != 0x030) && (Timeout));
-  DEBUG ((DEBUG_ERROR, "PCIe link ready (status=%x) Timeout=%d\n", Data, Timeout));
+  DEBUG ((DEBUG_VERBOSE, "PCIe link ready (status=%x) Timeout=%d\n", Data, Timeout));
 
   if ((Data & 0x30) != 0x30) {
     DEBUG ((DEBUG_ERROR, "PCIe link not ready (status=%x)\n", Data));
@@ -240,10 +215,6 @@ Bcm2711PciHostBridgeLibConstructor (
 
   // Change class code of the root port
   RMWRegister(BRCM_PCIE_CLASS, PCIE_RC_CFG_PRIV1_ID_VAL3_CLASS_CODE_MASK, 0x60400);
-
-  Data = RdRegister16(BRCM_PCIE_CAP_REGS + PCI_EXP_LNKSTA, 0);
-  DEBUG ((DEBUG_ERROR, "link up, %d Gbps x%u\n", Data & PCI_EXP_LNKSTA_CLS,
-    (Data & PCI_EXP_LNKSTA_NLW) >> PCI_EXP_LNKSTA_NLW_SHIFT));
 
   //
   // PCIe->SCB endian mode for BAR

--- a/Silicon/Broadcom/Bcm27xx/Library/Bcm2711PciSegmentLib/PciSegmentLib.c
+++ b/Silicon/Broadcom/Bcm27xx/Library/Bcm2711PciSegmentLib/PciSegmentLib.c
@@ -15,6 +15,7 @@
 #include <Library/BaseLib.h>
 #include <Library/DebugLib.h>
 #include <Library/IoLib.h>
+#include <Library/PcdLib.h>
 #include <Library/PciSegmentLib.h>
 #include <IndustryStandard/Bcm2711.h>
 

--- a/Silicon/Broadcom/Bcm27xx/Library/Bcm2711PciSegmentLib/PciSegmentLib.inf
+++ b/Silicon/Broadcom/Bcm27xx/Library/Bcm2711PciSegmentLib/PciSegmentLib.inf
@@ -28,6 +28,7 @@
   BaseLib
   DebugLib
   IoLib
+  PcdLib
 
-[Pcd]
-#  gEfiMdePkgTokenSpaceGuid.PcdPciExpressBaseAddress
+[FixedPcd]
+  gBcm27xxTokenSpaceGuid.PcdBcm27xxPciRegBase


### PR DESCRIPTION
I think this is my final round of general code cleanups. I'm mostly happy with it at the moment. There are also two bug fixes in this set.

The first is the MMIO base address shift/MASK wasn't right (I don't think this was causing problems as it was). The second is that I lowered the PcdDmaDeviceLimit to 3G, and this fixed the grub problem. So I guess I have one of the rpi's with the 3G bug? Actually, I still need to write a test case that tries DMA to various addresses to verify where exactly the limit is. I considered lowering it to 1G just to be on the safe side.

Also maybe of note in this set, is that I moved the MMIO addresses and PCIe register base into PCD's so that they can be dynamically set.

I expect these will be squashed into the original 4 patches too, if that is problematic I can squash them.

This was tested against, Ard's rpi4 edk2 branch.
