### PR TITLE
Pi4 dev4 genetstub so that we don't need a mac-address property in DSD

### DIFF
--- a/Platform/RaspberryPi/Drivers/Genet/Genet.c
+++ b/Platform/RaspberryPi/Drivers/Genet/Genet.c
@@ -1,0 +1,132 @@
+/** @file
+
+  Copyright (c) 2019, Jeremy Linton All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  This driver acts like a stub to set the BCM 
+  Genet MAC address, until the actual network driver
+  is in place. This should allow us to retrieve the
+  mac address directly from the hardware in supported
+  OS's rather than passing it via DSDT (which isn't 
+  ideal for a number of reasons, foremost the hardware
+  should be self describing).
+
+**/
+
+#include <Library/ArmLib.h>
+#include <Library/DebugLib.h>
+#include <Library/DevicePathLib.h>
+#include <Library/IoLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/UefiLib.h>
+
+#include <PiDxe.h>
+#include <Protocol/RpiFirmware.h>
+
+#define GENET_BASE                 0xfd580000  // len = 0x10000
+#define GENET_SYS_RBUF_FLUSH_CTRL  0x0008
+#define GENET_UMAC_MAC0            0x080C
+#define GENET_UMAC_MAC1            0x0810
+
+STATIC
+VOID
+RMWRegister (
+  UINT32                Offset,
+  UINT32                Mask,
+  UINT32                In
+  )
+{
+  EFI_PHYSICAL_ADDRESS  Addr = GENET_BASE;
+  UINT32                Data = 0;
+  UINT32                Shift;
+
+  Addr += Offset;
+  Shift = 1;
+  if (In) {
+    while (!(Mask & Shift))
+      Shift <<= 1;
+    Data = (MmioRead32 (Addr) & ~Mask) | ((In * Shift) & Mask);
+  } else {
+    Data = MmioRead32 (Addr) & ~Mask;
+  }
+
+  MmioWrite32 (Addr, Data);
+
+  ArmDataMemoryBarrier ();
+}
+
+STATIC
+VOID
+WdRegister (
+  UINT32                Offset,
+  UINT32                In
+  )
+{
+  EFI_PHYSICAL_ADDRESS  Base = GENET_BASE;
+
+  MmioWrite32 (Base + Offset, In);
+
+  ArmDataMemoryBarrier ();
+}
+
+
+
+STATIC VOID
+GenetMacInit (UINT8 *addr)
+{
+
+  // bring the umac out of reset
+  RMWRegister (GENET_SYS_RBUF_FLUSH_CTRL, 0x2, 1);
+  gBS->Stall (10);
+  RMWRegister (GENET_SYS_RBUF_FLUSH_CTRL, 0x2, 0);
+
+  // Update the MAC
+
+  WdRegister(GENET_UMAC_MAC0, (addr[0] << 24) | (addr[1] << 16) | (addr[2] << 8) | addr[3]);
+  WdRegister(GENET_UMAC_MAC1, (addr[4] << 8) | addr[5]);
+}
+
+/**
+  The entry point of Genet UEFI Driver.
+
+  @param  ImageHandle                The image handle of the UEFI Driver.
+  @param  SystemTable                A pointer to the EFI System Table.
+
+  @retval  EFI_SUCCESS               The Driver or UEFI Driver exited normally.
+  @retval  EFI_INCOMPATIBLE_VERSION  _gUefiDriverRevision is greater than
+                                     SystemTable->Hdr.Revision.
+
+**/
+EFI_STATUS
+EFIAPI
+GenetEntryPoint (
+  IN  EFI_HANDLE          ImageHandle,
+  IN  EFI_SYSTEM_TABLE    *SystemTable
+  )
+{
+  RASPBERRY_PI_FIRMWARE_PROTOCOL   *mFwProtocol;
+  EFI_STATUS Status;
+  UINT8 MacAddr[6];
+
+  DEBUG ((DEBUG_ERROR, "GENET:%a(): Init\n", __FUNCTION__));
+
+  Status = gBS->LocateProtocol (&gRaspberryPiFirmwareProtocolGuid, NULL,
+                  (VOID**)&mFwProtocol);
+  if (EFI_ERROR(Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: failed to locate RPi firmware protocol\n", __FUNCTION__));
+    return Status;
+  }
+  
+  // Get the MAC address from the firmware
+  Status = mFwProtocol->GetMacAddress (MacAddr);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_ERROR, "%a: failed to retrieve MAC address\n", __FUNCTION__));
+    return Status;
+  }
+
+  // Write it to the hardware
+  GenetMacInit (MacAddr);
+
+  return EFI_SUCCESS;
+}

--- a/Platform/RaspberryPi/Drivers/Genet/Genet.inf
+++ b/Platform/RaspberryPi/Drivers/Genet/Genet.inf
@@ -1,0 +1,39 @@
+## @file
+#
+# Copyright (c) 2020, Jeremy Linton All rights reserved.<BR>
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x0001001A
+  BASE_NAME                      = Genet
+  FILE_GUID                      = e2b1eaf3-50b7-4ae1-b79e-ec8020cb57ac
+  MODULE_TYPE                    = UEFI_DRIVER
+  VERSION_STRING                 = 0.1
+  ENTRY_POINT                    = GenetEntryPoint
+
+[Sources]
+  Genet.c
+
+[Packages]
+  ArmPkg/ArmPkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  MdePkg/MdePkg.dec
+  Platform/RaspberryPi/RaspberryPi.dec
+
+[LibraryClasses]
+  BaseLib
+  IoLib
+  SynchronizationLib
+  UefiDriverEntryPoint
+  UefiLib
+
+[Protocols]
+  gRaspberryPiFirmwareProtocolGuid              ## CONSUMES
+
+
+[Depex]
+  gRaspberryPiFirmwareProtocolGuid
+

--- a/Platform/RaspberryPi/RPi4/RPi4.dsc
+++ b/Platform/RaspberryPi/RPi4/RPi4.dsc
@@ -660,6 +660,7 @@ DEFINE TFA_BUILD_ARTIFACT = Platform/RaspberryPi/$(PLATFORM_NAME)/TrustedFirmwar
   # Networking stack
   #
 !include NetworkPkg/Network.dsc.inc
+  Platform/RaspberryPi/Drivers/Genet/Genet.inf
 
   #
   # RNG

--- a/Platform/RaspberryPi/RPi4/RPi4.fdf
+++ b/Platform/RaspberryPi/RPi4/RPi4.fdf
@@ -265,6 +265,7 @@ READ_LOCK_STATUS   = TRUE
   # Networking stack
   #
 !include NetworkPkg/Network.fdf.inc
+  INF Platform/RaspberryPi/Drivers/Genet/Genet.inf
 
   #
   # RNG


### PR DESCRIPTION
Since, I am nowhere near getting the full driver working, here is enough code to bring the umac out of reset and program the mac address. This leaves only the phy-mode property, and a BRCM/BCM assigned ID as open issues IMHO.

This allows the code I passed around previously to work, after the umac_reset() is removed (or wrapped with an if (!acpi)).

