### PR TITLE
Silicon/Broadcom/Net: Add Genet stub driver to setup MAC

### DIFF
--- a/Platform/RaspberryPi/Library/PlatformPcdLib/PlatformPcdLib.c
+++ b/Platform/RaspberryPi/Library/PlatformPcdLib/PlatformPcdLib.c
@@ -1,0 +1,59 @@
+/** @file
+ *
+ *  Copyright (c) 2020, Pete Batard <pete@akeo.ie>
+ * 
+ *  SPDX-License-Identifier: BSD-2-Clause-Patent
+ *
+ **/
+
+#include <Library/DebugLib.h>
+#include <Library/PcdLib.h>
+#include <Library/PrintLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/UefiLib.h>
+#include <Library/UefiRuntimeServicesTableLib.h>
+#include <Protocol/RpiFirmware.h>
+
+EFI_STATUS
+EFIAPI
+PlatformPcdLibConstructor (
+  IN EFI_HANDLE ImageHandle,
+  IN EFI_SYSTEM_TABLE *SystemTable
+  )
+{
+
+#if (FixedPcdGet64 (PcdBcmGenetRegistersAddress) != 0)
+  //
+  // If Genet is in use and a MAC address PCD has not been set, do it here.
+  //
+  EFI_STATUS                       Status;
+  UINT64                           MacAddr;
+  RASPBERRY_PI_FIRMWARE_PROTOCOL   *mFwProtocol;
+
+  Status = gBS->LocateProtocol (&gRaspberryPiFirmwareProtocolGuid, NULL,
+                  (VOID**)&mFwProtocol);
+  ASSERT_EFI_ERROR(Status);
+
+  //
+  // Get the MAC address from the firmware
+  //
+  Status = mFwProtocol->GetMacAddress ((UINT8*) &MacAddr);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((DEBUG_WARN, "%a: failed to retrieve MAC address\n", __FUNCTION__));
+  } else {
+    PcdSet64 (PcdBcmGenetMacAddress, MacAddr);
+  }
+#endif
+
+  return EFI_SUCCESS;
+}
+
+EFI_STATUS
+EFIAPI
+PlatformPcdLibDestructor (
+  IN EFI_HANDLE ImageHandle,
+  IN EFI_SYSTEM_TABLE *SystemTable
+  )
+{
+  return EFI_SUCCESS;
+}

--- a/Platform/RaspberryPi/Library/PlatformPcdLib/PlatformPcdLib.inf
+++ b/Platform/RaspberryPi/Library/PlatformPcdLib/PlatformPcdLib.inf
@@ -1,0 +1,44 @@
+#/** @file
+#
+#  Copyright (c) 2020, Pete Batard <pete@akeo.ie>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+#**/
+
+[Defines]
+  INF_VERSION                    = 0x0001001A
+  BASE_NAME                      = PlatformPcdLib
+  FILE_GUID                      = 3B8409D7-D3C7-4006-823B-BFB184435363
+  MODULE_TYPE                    = DXE_DRIVER
+  VERSION_STRING                 = 1.0
+  LIBRARY_CLASS                  = NULL|DXE_DRIVER UEFI_APPLICATION
+  CONSTRUCTOR                    = PlatformPcdLibConstructor
+  DESTRUCTOR                     = PlatformPcdLibDestructor
+
+[Sources]
+  PlatformPcdLib.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  Platform/RaspberryPi/RaspberryPi.dec
+  Silicon/Broadcom/Drivers/Net/BcmNet.dec
+
+[LibraryClasses]
+  UefiLib
+  DebugLib
+  PrintLib
+
+[Protocols]
+  gRaspberryPiFirmwareProtocolGuid              ## CONSUMES
+
+[Pcd]
+  gBcmNetTokenSpaceGuid.PcdBcmGenetMacAddress   ## SOMETIMES_PRODUCES
+
+[FixedPcd]
+  gBcmNetTokenSpaceGuid.PcdBcmGenetRegistersAddress
+
+[Depex]
+  gPcdProtocolGuid AND gRaspberryPiFirmwareProtocolGuid
+

--- a/Platform/RaspberryPi/RPi4/RPi4.dsc
+++ b/Platform/RaspberryPi/RPi4/RPi4.dsc
@@ -402,6 +402,7 @@
   gRaspberryPiTokenSpaceGuid.PcdExtendedMemoryBase|0x40000000
   gBcm27xxTokenSpaceGuid.PcdBcm27xxRegistersAddress|0xfc000000
   gBcm283xTokenSpaceGuid.PcdBcm283xRegistersAddress|0xfe000000
+  gBcmNetTokenSpaceGuid.PcdBcmGenetRegistersAddress|0xfd580000
 
   # PCIe specific addresses
   gBcm27xxTokenSpaceGuid.PcdBcm27xxPciRegBase|0xfd500000
@@ -648,6 +649,10 @@
   # Networking stack
   #
 !include NetworkPkg/Network.dsc.inc
+  Silicon/Broadcom/Drivers/Net/BcmGenetDxe/BcmGenetDxe.inf {
+    <LibraryClasses>
+      NULL|Platform/RaspberryPi/Library/PlatformPcdLib/PlatformPcdLib.inf
+  }
 
   #
   # RNG

--- a/Platform/RaspberryPi/RPi4/RPi4.fdf
+++ b/Platform/RaspberryPi/RPi4/RPi4.fdf
@@ -269,6 +269,7 @@ READ_LOCK_STATUS   = TRUE
   # Networking stack
   #
 !include NetworkPkg/Network.fdf.inc
+  INF Silicon/Broadcom/Drivers/Net/BcmGenetDxe/BcmGenetDxe.inf
 
   #
   # RNG

--- a/Silicon/Broadcom/Drivers/Net/BcmGenetDxe/BcmGenetDxe.inf
+++ b/Silicon/Broadcom/Drivers/Net/BcmGenetDxe/BcmGenetDxe.inf
@@ -1,0 +1,40 @@
+## @file
+#
+# Copyright (c) 2020, Jeremy Linton All rights reserved.<BR>
+#
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x0001001A
+  BASE_NAME                      = BcmGenetDxe
+  FILE_GUID                      = e2b1eaf3-50b7-4ae1-b79e-ec8020cb57ac
+  MODULE_TYPE                    = DXE_DRIVER
+  VERSION_STRING                 = 0.1
+  ENTRY_POINT                    = GenetEntryPoint
+
+[Sources]
+  Genet.c
+
+[Packages]
+  ArmPkg/ArmPkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+  MdePkg/MdePkg.dec
+  Silicon/Broadcom/Drivers/Net/BcmNet.dec
+
+[LibraryClasses]
+  ArmLib
+  BaseLib
+  IoLib
+  UefiDriverEntryPoint
+  UefiLib
+
+[FixedPcd]
+  gBcmNetTokenSpaceGuid.PcdBcmGenetRegistersAddress
+
+[Pcd]
+  gBcmNetTokenSpaceGuid.PcdBcmGenetMacAddress
+
+[Depex]
+  TRUE

--- a/Silicon/Broadcom/Drivers/Net/BcmGenetDxe/Genet.c
+++ b/Silicon/Broadcom/Drivers/Net/BcmGenetDxe/Genet.c
@@ -1,0 +1,119 @@
+/** @file
+
+  Copyright (c) 2020, Jeremy Linton All rights reserved.<BR>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+  This driver acts like a stub to set the Broadcom
+  Genet MAC address, until the actual network driver
+  is in place.
+
+  Currently, this only supports querying the MAC on a
+  Raspberry Pi platform, through a VideoCore call (exposed
+  through the RpiFirmware interface), but can be extented
+  to other platforms MAC initialization.
+
+**/
+
+#include <Library/ArmLib.h>
+#include <Library/DebugLib.h>
+#include <Library/IoLib.h>
+#include <Library/PcdLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/UefiLib.h>
+
+#include <Genet.h>
+#include <PiDxe.h>
+
+STATIC
+VOID
+RMWRegister (
+  UINT32                Offset,
+  UINT32                Mask,
+  UINT32                In
+  )
+{
+  EFI_PHYSICAL_ADDRESS  Addr;
+  UINT32                Data;
+  UINT32                Shift;
+
+  Addr = GENET_BASE_ADDRESS + Offset;
+  Data = 0;
+  Shift = 1;
+  if (In) {
+    while (!(Mask & Shift))
+      Shift <<= 1;
+    Data = (MmioRead32 (Addr) & ~Mask) | ((In * Shift) & Mask);
+  } else {
+    Data = MmioRead32 (Addr) & ~Mask;
+  }
+
+  MmioWrite32 (Addr, Data);
+
+  ArmDataMemoryBarrier ();
+}
+
+STATIC
+VOID
+WdRegister (
+  UINT32                Offset,
+  UINT32                In
+  )
+{
+  EFI_PHYSICAL_ADDRESS  Base = GENET_BASE_ADDRESS;
+
+  MmioWrite32 (Base + Offset, In);
+
+  ArmDataMemoryBarrier ();
+}
+
+STATIC
+VOID
+SetMacAddress (
+  UINT8*                MacAddr
+)
+{
+  // Bring the UMAC out of reset
+  RMWRegister (GENET_SYS_RBUF_FLUSH_CTRL, 0x2, 1);
+  gBS->Stall (10);
+  RMWRegister (GENET_SYS_RBUF_FLUSH_CTRL, 0x2, 0);
+
+  // Update the MAC
+  DEBUG ((DEBUG_INFO, "Setting MAC address %02X:%02X:%02X:%02X:%02X:%02X\n",
+    MacAddr[0], MacAddr[1], MacAddr[2], MacAddr[3], MacAddr[4], MacAddr[5]));
+
+  WdRegister (GENET_UMAC_MAC0, (MacAddr[0] << 24) | (MacAddr[1] << 16) |
+    (MacAddr[2] << 8) | MacAddr[3]);
+  WdRegister (GENET_UMAC_MAC1, (MacAddr[4] << 8) | MacAddr[5]);
+
+}
+
+/**
+  The entry point of Genet UEFI Driver.
+
+  @param  ImageHandle                The image handle of the UEFI Driver.
+  @param  SystemTable                A pointer to the EFI System Table.
+
+  @retval  EFI_SUCCESS               The Driver or UEFI Driver exited normally.
+  @retval  EFI_INCOMPATIBLE_VERSION  _gUefiDriverRevision is greater than
+                                     SystemTable->Hdr.Revision.
+
+**/
+EFI_STATUS
+EFIAPI
+GenetEntryPoint (
+  IN  EFI_HANDLE          ImageHandle,
+  IN  EFI_SYSTEM_TABLE    *SystemTable
+  )
+{
+  UINT64 MacAddr;
+
+  // Read the MAC address
+  MacAddr = PcdGet64 (PcdBcmGenetMacAddress);
+
+  if (MacAddr != 0) {
+    SetMacAddress ((UINT8*)&MacAddr);
+  }
+
+  return EFI_SUCCESS;
+}

--- a/Silicon/Broadcom/Drivers/Net/BcmGenetDxe/Genet.h
+++ b/Silicon/Broadcom/Drivers/Net/BcmGenetDxe/Genet.h
@@ -1,0 +1,20 @@
+/** @file
+
+  Copyright (c) 2020, Pete Batard <pete@akeo.ie>
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+
+**/
+
+#ifndef BCM_GENET_H__
+#define BCM_GENET_H__
+
+#include <Library/PcdLib.h>
+
+#define GENET_BASE_ADDRESS         (FixedPcdGet64 (PcdBcmGenetRegistersAddress))
+
+#define GENET_SYS_RBUF_FLUSH_CTRL  0x0008
+#define GENET_UMAC_MAC0            0x080c
+#define GENET_UMAC_MAC1            0x0810
+
+#endif /* BCM_GENET_H__ */

--- a/Silicon/Broadcom/Drivers/Net/BcmNet.dec
+++ b/Silicon/Broadcom/Drivers/Net/BcmNet.dec
@@ -1,0 +1,22 @@
+## @file
+#
+#  Copyright (c) 2020, Pete Batard <pete@akeo.ie>
+#
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  DEC_SPECIFICATION              = 0x0001001A
+  PACKAGE_NAME                   = BcmNetPkg
+  PACKAGE_GUID                   = 34E19823-D23A-41AB-9C09-ED1225B32DFF
+  PACKAGE_VERSION                = 1.0
+
+[Guids]
+  gBcmNetTokenSpaceGuid = {0x12b97d70, 0x9149, 0x4c2f, {0x82, 0xd5, 0xad, 0xa9, 0x1e, 0x92, 0x75, 0xa1}}
+
+[PcdsFixedAtBuild]
+  gBcmNetTokenSpaceGuid.PcdBcmGenetRegistersAddress|0x0|UINT32|0x00000001
+
+[PcdsDynamic]
+  gBcmNetTokenSpaceGuid.PcdBcmGenetMacAddress|0x0|UINT64|0x00000002


### PR DESCRIPTION
The RPi4 has a Gigabit Broadcom Genet platform device. In order to
assist in booting the platform in an ACPI environment, it is
desirable if the hardware can describe itself rather than passing
parameters via DSDT/DSD. One way to achieve this is to assure that
the adapter is preprogrammed with the correct ethernet MAC address
which, on the Raspberry Pi, can be achieved by using a dedicated
firmware interface call.

The driver is added under Silicon on account that Genet NICs are
not specific to the Raspberry Pi and could be extended for other
platforms. This is also why the dedicated PcdBcmGenetRpiMacInit
PCD is introduced for the RPi specific MAC initialization.

Signed-off-by: Pete Batard <pete@akeo.ie>